### PR TITLE
feat(diff): add support for mercurial

### DIFF
--- a/doc/mini-diff.txt
+++ b/doc/mini-diff.txt
@@ -29,8 +29,8 @@ Features:
 - Supports three diff sources:
     - |MiniDiff.gen_source.git()|: Use git repository as the source to diff
       the current buffer.
-    - |MiniDiff.gen_source.hg()|: Use mercurial repository as the source to
-      diff the current buffer.
+    - |MiniDiff.gen_source.mercurial()|: Use mercurial repository as the
+      source to diff the current buffer.
     - |MiniDiff.gen_source.save()|: Diff with respect to the file on disk.
 
 What it doesn't do:
@@ -542,7 +542,7 @@ Examples: >lua
   -- Multiple sources (attempted to attach in order)
   diff.setup({ source = {
     diff.gen_source.git(),
-    diff.gen_source.hg(),
+    diff.gen_source.mercurial(),
     diff.gen_source.save()
   } })
 <
@@ -565,13 +565,14 @@ Return ~
 `(table)` Source. See |MiniDiff-source-specification|.
 
 ------------------------------------------------------------------------------
-                                                      *MiniDiff.gen_source.hg()*
-                           `MiniDiff.gen_source.hg`()
-Merurial/hg source
+                                               *MiniDiff.gen_source.mercurial()*
+                       `MiniDiff.gen_source.mercurial`()
+Merurial source
 
 Uses file text from mercurial's `dirstate` as reference. This results in:
-- "Add" hunks represent text present in current buffer, but not in hg repo.
-- "Change" hunks represent modified text not in hg repo.
+- "Add" hunks represent text present in current buffer, but not in
+  mercurial repo.
+- "Change" hunks represent modified text not in mercurial repo.
 - "Delete" hunks represent text deleted from repo.
 
 Notes:

--- a/doc/mini-diff.txt
+++ b/doc/mini-diff.txt
@@ -26,6 +26,13 @@ Features:
     - "Hunk range under cursor" textobject to be used as operator target.
     - Navigate to first/previous/next/last hunk. See |MiniDiff.goto_hunk()|.
 
+- Supports three diff sources:
+    - |MiniDiff.gen_source.git()|: Use git repository as the source to diff
+      the current buffer.
+    - |MiniDiff.gen_source.hg()|: Use mercurial repository as the source to
+      diff the current buffer.
+    - |MiniDiff.gen_source.save()|: Diff with respect to the file on disk.
+
 What it doesn't do:
 
 - Provide functionality to work directly with Git outside of visualizing
@@ -533,7 +540,11 @@ Examples: >lua
   diff.setup({ source = diff.gen_source.save() })
 
   -- Multiple sources (attempted to attach in order)
-  diff.setup({ source = { diff.gen_source.git(), diff.gen_source.save() } })
+  diff.setup({ source = {
+    diff.gen_source.git(),
+    diff.gen_source.hg(),
+    diff.gen_source.save()
+  } })
 <
 ------------------------------------------------------------------------------
                                                      *MiniDiff.gen_source.git()*
@@ -549,6 +560,22 @@ Applying hunks means staging, a.k.a adding to index.
 Notes:
 - Requires Git version at least 2.38.0.
 - There is no capability for unstaging hunks. Use full Git client for that.
+
+Return ~
+`(table)` Source. See |MiniDiff-source-specification|.
+
+------------------------------------------------------------------------------
+                                                      *MiniDiff.gen_source.hg()*
+                           `MiniDiff.gen_source.hg`()
+Merurial/hg source
+
+Uses file text from mercurial's `dirstate` as reference. This results in:
+- "Add" hunks represent text present in current buffer, but not in hg repo.
+- "Change" hunks represent modified text not in hg repo.
+- "Delete" hunks represent text deleted from repo.
+
+Notes:
+- Requires Git version at least 6.9.4.
 
 Return ~
 `(table)` Source. See |MiniDiff-source-specification|.

--- a/lua/mini/diff.lua
+++ b/lua/mini/diff.lua
@@ -984,8 +984,8 @@ H.operator_cache = {}
 -- Common extmark data for supported styles
 --stylua: ignore
 H.style_extmark_data = {
-  sign   = { hl_group_prefix = 'MiniDiffSign', field = 'sign_hl_group' },
-  number = { hl_group_prefix = 'MiniDiffSign', field = 'number_hl_group' },
+  sign    = { hl_group_prefix = 'MiniDiffSign', field = 'sign_hl_group' },
+  number  = { hl_group_prefix = 'MiniDiffSign', field = 'number_hl_group' },
 }
 
 -- Suffix for overlay virtual lines to be highlighted as full line
@@ -1004,12 +1004,9 @@ H.vimdiff_opts = { result_type = 'indices', ctxlen = 0, interhunkctxlen = 0 }
 -- reduce noisiness (chosen as slightly less than average English word length)
 --stylua: ignore
 H.worddiff_opts = {
-  algorithm = 'minimal',
-  result_type = 'indices',
-  ctxlen = 0,
-  interhunkctxlen = 4,
-  indent_heuristic = false,
-  linematch = 0
+  algorithm = 'minimal',    result_type = 'indices',
+  ctxlen = 0,               interhunkctxlen = 4,
+  indent_heuristic = false, linematch = 0
 }
 
 -- BOM bytes prepended to buffer text if 'bomb' is enabled. See `:h bom-bytes`.
@@ -1081,14 +1078,14 @@ H.apply_config = function(config)
   H.map(modes, mappings.textobject, '<Cmd>lua MiniDiff.textobject()<CR>', { desc = 'Hunk range textobject' })
 
   --stylua: ignore start
-  H.map({ 'n', 'x' }, mappings.goto_first, "<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
-  H.map('o', mappings.goto_first, "V<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_prev, "<Cmd>lua MiniDiff.goto_hunk('prev')<CR>", { desc = 'Previous hunk' })
-  H.map('o', mappings.goto_prev, "V<Cmd>lua MiniDiff.goto_hunk('prev')<CR>", { desc = 'Previous hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_next, "<Cmd>lua MiniDiff.goto_hunk('next')<CR>", { desc = 'Next hunk' })
-  H.map('o', mappings.goto_next, "V<Cmd>lua MiniDiff.goto_hunk('next')<CR>", { desc = 'Next hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_last, "<Cmd>lua MiniDiff.goto_hunk('last')<CR>", { desc = 'Last hunk' })
-  H.map('o', mappings.goto_last, "V<Cmd>lua MiniDiff.goto_hunk('last')<CR>", { desc = 'Last hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_first,  "<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
+  H.map('o',          mappings.goto_first, "V<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_prev,   "<Cmd>lua MiniDiff.goto_hunk('prev')<CR>",  { desc = 'Previous hunk' })
+  H.map('o',          mappings.goto_prev,  "V<Cmd>lua MiniDiff.goto_hunk('prev')<CR>",  { desc = 'Previous hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_next,   "<Cmd>lua MiniDiff.goto_hunk('next')<CR>",  { desc = 'Next hunk' })
+  H.map('o',          mappings.goto_next,  "V<Cmd>lua MiniDiff.goto_hunk('next')<CR>",  { desc = 'Next hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_last,   "<Cmd>lua MiniDiff.goto_hunk('last')<CR>",  { desc = 'Last hunk' })
+  H.map('o',          mappings.goto_last,  "V<Cmd>lua MiniDiff.goto_hunk('last')<CR>",  { desc = 'Last hunk' })
   --stylua: ignore end
 
   -- Register decoration provider which actually makes visualization
@@ -1118,15 +1115,15 @@ H.create_default_hl = function()
   end
 
   local has_core_diff_hl = vim.fn.has('nvim-0.10') == 1
-  hi('MiniDiffSignAdd', { link = has_core_diff_hl and 'Added' or 'diffAdded' })
-  hi('MiniDiffSignChange', { link = has_core_diff_hl and 'Changed' or 'diffChanged' })
-  hi('MiniDiffSignDelete', { link = has_core_diff_hl and 'Removed' or 'diffRemoved' })
-  hi('MiniDiffOverAdd', { link = 'DiffAdd' })
-  hi('MiniDiffOverChange', { link = 'DiffText' })
-  hi('MiniDiffOverChangeBuf', { link = 'MiniDiffOverChange' })
-  hi('MiniDiffOverContext', { link = 'DiffChange' })
+  hi('MiniDiffSignAdd',        { link = has_core_diff_hl and 'Added' or 'diffAdded' })
+  hi('MiniDiffSignChange',     { link = has_core_diff_hl and 'Changed' or 'diffChanged' })
+  hi('MiniDiffSignDelete',     { link = has_core_diff_hl and 'Removed' or 'diffRemoved'  })
+  hi('MiniDiffOverAdd',        { link = 'DiffAdd' })
+  hi('MiniDiffOverChange',     { link = 'DiffText' })
+  hi('MiniDiffOverChangeBuf',  { link = 'MiniDiffOverChange'})
+  hi('MiniDiffOverContext',    { link = 'DiffChange' })
   hi('MiniDiffOverContextBuf', {})
-  hi('MiniDiffOverDelete', { link = 'DiffDelete' })
+  hi('MiniDiffOverDelete',     { link = 'DiffDelete'  })
 end
 
 H.is_disabled = function(buf_id)
@@ -1272,7 +1269,7 @@ H.convert_view_to_extmark_opts = function(view)
   local field, hl_group_prefix = extmark_data.field, extmark_data.hl_group_prefix
   --stylua: ignore
   return {
-    add = { [field] = hl_group_prefix .. 'Add', sign_text = signs.add, priority = view.priority, invalidate = H.extmark_invalidate },
+    add =    { [field] = hl_group_prefix .. 'Add',    sign_text = signs.add,    priority = view.priority, invalidate = H.extmark_invalidate },
     change = { [field] = hl_group_prefix .. 'Change', sign_text = signs.change, priority = view.priority, invalidate = H.extmark_invalidate },
     delete = { [field] = hl_group_prefix .. 'Delete', sign_text = signs.delete, priority = view.priority, invalidate = H.extmark_invalidate },
   }
@@ -1458,7 +1455,7 @@ H.append_overlay_change = function(overlay_lines, hunk, ref_lines, buf_lines, pr
       -- Defer actually computing word diff until in decoration provider as it
       -- will compute only for displayed lines
       local data =
-      { type = 'change_worddiff', ref_line = ref_lines[ref_n], buf_line = buf_lines[buf_n], priority = priority }
+        { type = 'change_worddiff', ref_line = ref_lines[ref_n], buf_line = buf_lines[buf_n], priority = priority }
       H.append_overlay(overlay_lines, buf_n, data)
     end
     return
@@ -1499,7 +1496,7 @@ H.draw_overlay_line = function(buf_id, ns_id, row, data)
 
   -- "Change"/"Delete" hunks show affected reference range as virtual lines
   opts.virt_lines, opts.virt_lines_above, opts.virt_lines_overflow =
-      data.lines, data.show_above, H.extmark_virt_lines_overflow
+    data.lines, data.show_above, H.extmark_virt_lines_overflow
   H.set_extmark(buf_id, ns_id, row, 0, opts)
 end
 
@@ -1520,9 +1517,7 @@ H.draw_overlay_line_worddiff = function(buf_id, ns_id, row, data)
 
   --stylua: ignore
   local ref_opts = {
-    virt_lines = { virt_line },
-    virt_lines_above = true,
-    virt_lines_overflow = H.extmark_virt_lines_overflow,
+    virt_lines = { virt_line }, virt_lines_above = true, virt_lines_overflow = H.extmark_virt_lines_overflow,
     priority = priority,
   }
   H.set_extmark(buf_id, ns_id, row, 0, ref_opts)
@@ -1536,7 +1531,7 @@ H.draw_overlay_line_worddiff = function(buf_id, ns_id, row, data)
     H.set_extmark(buf_id, ns_id, row, part[1] - 1 - off, buf_opts)
   end
   local context_opts =
-  { end_row = row + 1, end_col = 0, hl_group = 'MiniDiffOverContextBuf', hl_eol = true, priority = priority - 1 }
+    { end_row = row + 1, end_col = 0, hl_group = 'MiniDiffOverContextBuf', hl_eol = true, priority = priority - 1 }
   H.set_extmark(buf_id, ns_id, row, 0, context_opts)
 end
 

--- a/lua/mini/diff.lua
+++ b/lua/mini/diff.lua
@@ -950,7 +950,7 @@ MiniDiff.fail_attach = function(buf_id)
 
   -- Try attaching next source
   buf_cache.source_id = buf_cache.source_id + 1
-  local attach_output = H.get_active_source(H.cache[buf_id]).attach(buf_id)
+  local attach_output = H.get_active_source(buf_cache).attach(buf_id)
   if attach_output == false then MiniDiff.fail_attach(buf_id) end
 end
 
@@ -1755,8 +1755,8 @@ H.dvcs_start_watching_index = function(buf_id, path, watch_index_opts)
       H.cache[buf_id] = nil
       return
     end
+    H.dvcs_cache[buf_id] = nil
     MiniDiff.fail_attach(buf_id)
-    H.dvcs_cache[buf_id] = {}
   end)
 
   local process, stdout_feed = nil, {}

--- a/lua/mini/diff.lua
+++ b/lua/mini/diff.lua
@@ -923,8 +923,8 @@ H.operator_cache = {}
 -- Common extmark data for supported styles
 --stylua: ignore
 H.style_extmark_data = {
-  sign    = { hl_group_prefix = 'MiniDiffSign', field = 'sign_hl_group' },
-  number  = { hl_group_prefix = 'MiniDiffSign', field = 'number_hl_group' },
+  sign   = { hl_group_prefix = 'MiniDiffSign', field = 'sign_hl_group' },
+  number = { hl_group_prefix = 'MiniDiffSign', field = 'number_hl_group' },
 }
 
 -- Suffix for overlay virtual lines to be highlighted as full line
@@ -943,9 +943,12 @@ H.vimdiff_opts = { result_type = 'indices', ctxlen = 0, interhunkctxlen = 0 }
 -- reduce noisiness (chosen as slightly less than average English word length)
 --stylua: ignore
 H.worddiff_opts = {
-  algorithm = 'minimal',    result_type = 'indices',
-  ctxlen = 0,               interhunkctxlen = 4,
-  indent_heuristic = false, linematch = 0
+  algorithm = 'minimal',
+  result_type = 'indices',
+  ctxlen = 0,
+  interhunkctxlen = 4,
+  indent_heuristic = false,
+  linematch = 0
 }
 
 -- BOM bytes prepended to buffer text if 'bomb' is enabled. See `:h bom-bytes`.
@@ -1017,14 +1020,14 @@ H.apply_config = function(config)
   H.map(modes, mappings.textobject, '<Cmd>lua MiniDiff.textobject()<CR>', { desc = 'Hunk range textobject' })
 
   --stylua: ignore start
-  H.map({ 'n', 'x' }, mappings.goto_first,  "<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
-  H.map('o',          mappings.goto_first, "V<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_prev,   "<Cmd>lua MiniDiff.goto_hunk('prev')<CR>",  { desc = 'Previous hunk' })
-  H.map('o',          mappings.goto_prev,  "V<Cmd>lua MiniDiff.goto_hunk('prev')<CR>",  { desc = 'Previous hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_next,   "<Cmd>lua MiniDiff.goto_hunk('next')<CR>",  { desc = 'Next hunk' })
-  H.map('o',          mappings.goto_next,  "V<Cmd>lua MiniDiff.goto_hunk('next')<CR>",  { desc = 'Next hunk' })
-  H.map({ 'n', 'x' }, mappings.goto_last,   "<Cmd>lua MiniDiff.goto_hunk('last')<CR>",  { desc = 'Last hunk' })
-  H.map('o',          mappings.goto_last,  "V<Cmd>lua MiniDiff.goto_hunk('last')<CR>",  { desc = 'Last hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_first, "<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
+  H.map('o', mappings.goto_first, "V<Cmd>lua MiniDiff.goto_hunk('first')<CR>", { desc = 'First hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_prev, "<Cmd>lua MiniDiff.goto_hunk('prev')<CR>", { desc = 'Previous hunk' })
+  H.map('o', mappings.goto_prev, "V<Cmd>lua MiniDiff.goto_hunk('prev')<CR>", { desc = 'Previous hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_next, "<Cmd>lua MiniDiff.goto_hunk('next')<CR>", { desc = 'Next hunk' })
+  H.map('o', mappings.goto_next, "V<Cmd>lua MiniDiff.goto_hunk('next')<CR>", { desc = 'Next hunk' })
+  H.map({ 'n', 'x' }, mappings.goto_last, "<Cmd>lua MiniDiff.goto_hunk('last')<CR>", { desc = 'Last hunk' })
+  H.map('o', mappings.goto_last, "V<Cmd>lua MiniDiff.goto_hunk('last')<CR>", { desc = 'Last hunk' })
   --stylua: ignore end
 
   -- Register decoration provider which actually makes visualization
@@ -1054,15 +1057,15 @@ H.create_default_hl = function()
   end
 
   local has_core_diff_hl = vim.fn.has('nvim-0.10') == 1
-  hi('MiniDiffSignAdd',        { link = has_core_diff_hl and 'Added' or 'diffAdded' })
-  hi('MiniDiffSignChange',     { link = has_core_diff_hl and 'Changed' or 'diffChanged' })
-  hi('MiniDiffSignDelete',     { link = has_core_diff_hl and 'Removed' or 'diffRemoved'  })
-  hi('MiniDiffOverAdd',        { link = 'DiffAdd' })
-  hi('MiniDiffOverChange',     { link = 'DiffText' })
-  hi('MiniDiffOverChangeBuf',  { link = 'MiniDiffOverChange'})
-  hi('MiniDiffOverContext',    { link = 'DiffChange' })
+  hi('MiniDiffSignAdd', { link = has_core_diff_hl and 'Added' or 'diffAdded' })
+  hi('MiniDiffSignChange', { link = has_core_diff_hl and 'Changed' or 'diffChanged' })
+  hi('MiniDiffSignDelete', { link = has_core_diff_hl and 'Removed' or 'diffRemoved' })
+  hi('MiniDiffOverAdd', { link = 'DiffAdd' })
+  hi('MiniDiffOverChange', { link = 'DiffText' })
+  hi('MiniDiffOverChangeBuf', { link = 'MiniDiffOverChange' })
+  hi('MiniDiffOverContext', { link = 'DiffChange' })
   hi('MiniDiffOverContextBuf', {})
-  hi('MiniDiffOverDelete',     { link = 'DiffDelete'  })
+  hi('MiniDiffOverDelete', { link = 'DiffDelete' })
 end
 
 H.is_disabled = function(buf_id)
@@ -1208,7 +1211,7 @@ H.convert_view_to_extmark_opts = function(view)
   local field, hl_group_prefix = extmark_data.field, extmark_data.hl_group_prefix
   --stylua: ignore
   return {
-    add =    { [field] = hl_group_prefix .. 'Add',    sign_text = signs.add,    priority = view.priority, invalidate = H.extmark_invalidate },
+    add = { [field] = hl_group_prefix .. 'Add', sign_text = signs.add, priority = view.priority, invalidate = H.extmark_invalidate },
     change = { [field] = hl_group_prefix .. 'Change', sign_text = signs.change, priority = view.priority, invalidate = H.extmark_invalidate },
     delete = { [field] = hl_group_prefix .. 'Delete', sign_text = signs.delete, priority = view.priority, invalidate = H.extmark_invalidate },
   }
@@ -1394,7 +1397,7 @@ H.append_overlay_change = function(overlay_lines, hunk, ref_lines, buf_lines, pr
       -- Defer actually computing word diff until in decoration provider as it
       -- will compute only for displayed lines
       local data =
-        { type = 'change_worddiff', ref_line = ref_lines[ref_n], buf_line = buf_lines[buf_n], priority = priority }
+      { type = 'change_worddiff', ref_line = ref_lines[ref_n], buf_line = buf_lines[buf_n], priority = priority }
       H.append_overlay(overlay_lines, buf_n, data)
     end
     return
@@ -1435,7 +1438,7 @@ H.draw_overlay_line = function(buf_id, ns_id, row, data)
 
   -- "Change"/"Delete" hunks show affected reference range as virtual lines
   opts.virt_lines, opts.virt_lines_above, opts.virt_lines_overflow =
-    data.lines, data.show_above, H.extmark_virt_lines_overflow
+      data.lines, data.show_above, H.extmark_virt_lines_overflow
   H.set_extmark(buf_id, ns_id, row, 0, opts)
 end
 
@@ -1456,7 +1459,9 @@ H.draw_overlay_line_worddiff = function(buf_id, ns_id, row, data)
 
   --stylua: ignore
   local ref_opts = {
-    virt_lines = { virt_line }, virt_lines_above = true, virt_lines_overflow = H.extmark_virt_lines_overflow,
+    virt_lines = { virt_line },
+    virt_lines_above = true,
+    virt_lines_overflow = H.extmark_virt_lines_overflow,
     priority = priority,
   }
   H.set_extmark(buf_id, ns_id, row, 0, ref_opts)
@@ -1470,7 +1475,7 @@ H.draw_overlay_line_worddiff = function(buf_id, ns_id, row, data)
     H.set_extmark(buf_id, ns_id, row, part[1] - 1 - off, buf_opts)
   end
   local context_opts =
-    { end_row = row + 1, end_col = 0, hl_group = 'MiniDiffOverContextBuf', hl_eol = true, priority = priority - 1 }
+  { end_row = row + 1, end_col = 0, hl_group = 'MiniDiffOverContextBuf', hl_eol = true, priority = priority - 1 }
   H.set_extmark(buf_id, ns_id, row, 0, context_opts)
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Mercurial follows a very similar patter to Git: (1) It has an index pointing to the latest changes in the repo (`dirstate`) and (2) we are able to `cat` the file content of files in the repository.

This patch does ~three~ two things:
1. ~Format `diff.lua` with `lua_ls`. If this is not ok, I can add a revert of it.~
2. Parameterize Git handling so that it accept a generic `index`, command to find the repo directory, and command to get files in the repo. Methods are renamed `s/git_/dvcs_/` to make it clear that they are more generic now.
3. Add mercurial support by populating the parameters created above with the correct values.