### PR TITLE
fix(deps): Git environment variables would break mini.deps

### DIFF
--- a/lua/mini/deps.lua
+++ b/lua/mini/deps.lua
@@ -1489,7 +1489,10 @@ H.cli_run = function(jobs)
     -- Prepare data for `vim.loop.spawn`
     local executable, args = command[1], vim.list_slice(command, 2, #command)
     local process, stdout, stderr = nil, vim.loop.new_pipe(), vim.loop.new_pipe()
-    local spawn_opts = { args = args, cwd = cwd, stdio = { nil, stdout, stderr } }
+    local env = { GIT_WORK_TREE = cwd, GIT_DIR = vim.fs.joinpath(cwd, '.git') }
+    if not vim.uv.fs_stat(env.GIT_DIR) then env = {} end
+
+    local spawn_opts = { args = args, cwd = cwd, env = env, stdio = { nil, stdout, stderr } }
 
     local on_exit = function(code)
       -- Process only not already closing job


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

As part of my workflow, I use a Git bare repository. For this, I have a Lua script for Neovim to automatically detect and set up environment variables so that it can work with other Git integration plugins. In particular, I define `vim.env.GIT_WORK_TREE` and `vim.env.GIT_DIR`.

When I run `DepsUpdate`, the update fails and the remote origin for the git repository that Neovim was set up to follow with the aforementioned environment variables changes to the last plugin I added with mini.deps.

This PR aims to fix this issue by explicitly not using any environment variables when running git from mini.deps.