### PR TITLE
fix(sessions): support sessions names with leading dot

### DIFF
--- a/lua/mini/sessions.lua
+++ b/lua/mini/sessions.lua
@@ -486,11 +486,9 @@ H.detect_sessions_global = function(global_dir)
   end
 
   -- Find global sessions
-  local globs = vim.fn.globpath(global_dir, '*')
-  if #globs == 0 then return {} end
-
   local res = {}
-  for _, f in pairs(vim.split(globs, '\n')) do
+  for name in vim.fs.dir(global_dir) do
+    local f = global_dir .. '/' .. name
     if H.is_readable_file(f) then
       local s = H.new_session(f, 'global')
       res[s.name] = s

--- a/tests/test_sessions.lua
+++ b/tests/test_sessions.lua
@@ -237,7 +237,7 @@ T['setup()']['detects sessions and respects `config.directory`'] = function()
   eq(type(detected), 'table')
   local keys = vim.tbl_keys(detected)
   table.sort(keys)
-  eq(keys, { 'Session.vim', 'session1', 'session2.vim', 'session3.lua' })
+  eq(keys, { '.session', 'Session.vim', 'session1', 'session2.vim', 'session3.lua' })
 
   -- Elements should have correct structure
   local cur_dir = child.fn.getcwd()


### PR DESCRIPTION
Resolve #1967

Before concatenating `global_dir` and filename with `/`, I confirmed that `global_dir` was already normalized (you do that in `H.full_path`. I did not use the `type` returned by the iterator of `vim.fs.dir` because you already check the type in `H.is_readable_file`, so it would be a duplicative check.

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
