### PR TITLE
fix(files): allow leading // or \\ on windows for UNC paths

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2596,7 +2596,7 @@ end
 
 H.fs_normalize_path = function(path) return (path:gsub('/+', '/'):gsub('(.)/$', '%1')) end
 if H.is_windows then
-  H.fs_normalize_path = function(path) return (path:gsub('\\', '/'):gsub('/+', '/'):gsub('(.)[\\/]$', '%1')) end
+  H.fs_normalize_path = function(path) return (path:gsub('\\', '/'):gsub("([^/])/+", "%1/"):gsub('(.)[\\/]$', '%1')) end
 end
 
 H.fs_is_imaginary_path = function(path) return path:sub(-1) == '\000' end

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2596,7 +2596,7 @@ end
 
 H.fs_normalize_path = function(path) return (path:gsub('/+', '/'):gsub('(.)/$', '%1')) end
 if H.is_windows then
-  H.fs_normalize_path = function(path) return (path:gsub('\\', '/'):gsub("([^/])/+", "%1/"):gsub('(.)[\\/]$', '%1')) end
+  H.fs_normalize_path = function(path) return (path:gsub('\\', '/'):gsub('([^/])/+', '%1/'):gsub('(.)[\\/]$', '%1')) end
 end
 
 H.fs_is_imaginary_path = function(path) return path:sub(-1) == '\000' end


### PR DESCRIPTION
I noticed on windows when trying to browse a file share using a UNC path (//server/share or \\server\share) the leading slash was eaten as part of the file normalization. 

This PR modifies the windows normalization function on windows to allow two leading slashes, but otherwise remove any repeats.

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
