### PR TITLE
fix: fix ts_range_to_region for nodes that end with newlines

### DIFF
--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -990,11 +990,22 @@ MiniAi.gen_spec.treesitter = function(ai_captures, opts)
   -- `row1-col1-byte1-row2-col2-byte2` (i.e. "range six") format.
   local ts_range_to_region = function(r)
     -- The `master` branch of 'nvim-treesitter' can return "range four" format
-    -- if it uses custom directives, like `#make-range!`. Due ot the fact that
+    -- if it uses custom directives, like `#make-range!`. Due to the fact that
     -- it doesn't fully mock the `TSNode:range()` method to return "range six".
     -- TODO: Remove after 'nvim-treesitter' `master` branch support is dropped.
     local offset = #r == 4 and -1 or 0
-    return { from = { line = r[1] + 1, col = r[2] + 1 }, to = { line = r[4 + offset] + 1, col = r[5 + offset] } }
+    local reg = { from = { line = r[1] + 1, col = r[2] + 1 }, to = { line = r[4 + offset] + 1, col = r[5 + offset] } }
+
+    -- When a node ends with a newline, its end point changes from
+    -- row-inclusive, col-exclusive to row-exclusive, col-0
+    if reg.to.col == 0 then
+      local buf_id = vim.api.nvim_get_current_buf()
+      local line = vim.api.nvim_buf_get_lines(buf_id, reg.to.line - 2, reg.to.line - 1, true)[1]
+
+      reg.to.line = reg.to.line - 1
+      reg.to.col = #line
+    end
+    return reg
   end
 
   return function(ai_type, _, _)

--- a/tests/mock-treesitter/queries/lua/textobjects.scm
+++ b/tests/mock-treesitter/queries/lua/textobjects.scm
@@ -25,3 +25,5 @@
 (string) @string
 
 ((string) @string_offset (#offset! @string_offset 0 1 0 -2))
+
+(chunk) @chunk.outer

--- a/tests/mock-treesitter/queries/lua/textobjects.scm
+++ b/tests/mock-treesitter/queries/lua/textobjects.scm
@@ -26,4 +26,4 @@
 
 ((string) @string_offset (#offset! @string_offset 0 1 0 -2))
 
-(chunk) @chunk.outer
+(chunk [(function_declaration) (assignment_statement)]* @chunk.inner) @chunk.outer

--- a/tests/test_ai.lua
+++ b/tests/test_ai.lua
@@ -844,6 +844,15 @@ T['gen_spec']['treesitter()']['works with quantified captures'] = function()
   validate_find(lines, { 3, 0 }, { 'a', 'P', { n_times = 3 } }, { { 3, 19 }, { 3, 23 } })
 end
 
+T['gen_spec']['treesitter()']['works with row-exclusive, col-0 end range'] = function()
+  child.lua([[MiniAi.config.custom_textobjects = {
+    c = MiniAi.gen_spec.treesitter({ a = '@chunk.outer', i = '@chunk.outer' }),
+  }]])
+
+  local lines = get_lines()
+  validate_find(lines, { 1, 0 }, { 'a', 'c' }, { { 1, 1 }, { 13, 8 } })
+end
+
 T['gen_spec']['treesitter()']['respects plugin options'] = function()
   local lines = get_lines()
 

--- a/tests/test_surround.lua
+++ b/tests/test_surround.lua
@@ -382,6 +382,19 @@ T['gen_spec']['input']['treesitter()']['works with quantified captures'] = funct
   validate(21, 'function M.a(u, vv<www>)')
 end
 
+T['gen_spec']['input']['treesitter()']['works with row-exclusive, col-0 end range'] = function()
+  if child.fn.has('nvim-0.10') == 0 then
+    MiniTest.skip('`Query:iter_matches()` returning several nodes requires Neovim>=0.10')
+  end
+
+  child.lua([[MiniSurround.config.custom_surroundings = {
+    c = { input = MiniSurround.gen_spec.input.treesitter({ outer = '@chunk.outer', inner = '@chunk.inner' }) }
+  }]])
+
+  local lines = get_lines()
+  validate_find(lines, { 4, 0 }, { { 11, 2 }, { 13, 7 }, { 1, 0 }, { 2, 0 } }, type_keys, 'sf', 'c')
+end
+
 T['gen_spec']['input']['treesitter()']['respects plugin options'] = function()
   local lines = get_lines()
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Fixes the issue mentioned in https://github.com/nvim-mini/mini.nvim/pull/2010#issuecomment-3300309430

Instead of only checking this for the last line of the buffer (which previously would incorrectly exclude some regions), this PR modifies all the ranges with an end that's row-exclusive, col-0 to be row-inclusive, col-exclusive (just like for nodes that don't end with a newline).

For reference, from https://github.com/nvim-mini/mini.nvim/pull/2010#issuecomment-3300404732

> I asked in the "Neovim treesitter" matrix channel and clason explained to me that, if a node contains a trailing newline, it's end_ will change from row-inclusive, col-exclusive to row-exclusive, col-0.