### PR TITLE
feat(extra): immediately call vim.lsp.buf[scope] if one result

### DIFF
--- a/lua/mini/extra.lua
+++ b/lua/mini/extra.lua
@@ -1984,6 +1984,10 @@ H.lsp_make_on_list = function(source, opts)
   end
 
   return function(data)
+    if vim.tbl_count(data.items) == 1 then
+      vim.lsp.buf[source]()
+      return
+    end
     local items = data.items
     for _, item in ipairs(data.items) do
       item.text, item.path = item.text or '', item.filename or nil


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

if lsp call results in 1 entry, it immediately calls the appropriate `vim.lsp.buf` handler without displaying the picker. it seemed kind of annoying that if e.g. "go to definition" had only one result, you still had to press enter once more to go there. 

hopefully this is something that's okay to open a PR for. i'm open to any sort of feedback!