### PR TITLE
feat(completion): add abbr_hlgroup for deprecated items

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -1256,6 +1256,15 @@ H.lsp_completion_response_items_to_complete_items = function(items)
 
     local lsp_data = { item = item, item_id = i }
     lsp_data.needs_snippet_insert = needs_snippet_insert
+
+    local abbr_hlgroup = ""
+    if
+      item.deprecated
+      or vim.list_contains((item.tags or {}), vim.lsp.protocol.CompletionTag.Deprecated)
+    then
+      abbr_hlgroup = 'DiagnosticDeprecated'
+    end
+
     table.insert(res, {
       -- Show less for snippet items (usually less confusion), but preserve
       -- built-in filtering capabilities (as it uses `word` to filter).
@@ -1263,6 +1272,7 @@ H.lsp_completion_response_items_to_complete_items = function(items)
       abbr = item.label,
       kind = item_kinds[item.kind] or 'Unknown',
       kind_hlgroup = item.kind_hlgroup,
+      abbr_hlgroup = abbr_hlgroup,
       menu = label_detail,
       -- NOTE: info will be attempted to resolve, use snippet text as fallback
       info = needs_snippet_insert and word or nil,


### PR DESCRIPTION
Use the DiagnosticDeprecated hlgroup to differentiate between deprecated vs normal items in the completion menu.

Took "inspiration" from here https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/completion.lua#L320

before:
<img width="422" height="273" alt="image" src="https://github.com/user-attachments/assets/6edf288d-4c88-4d41-854f-70d87559ce9a" />

after:
<img width="433" height="280" alt="image" src="https://github.com/user-attachments/assets/26ef1cfb-9a3e-42ca-b207-232a00a45d8d" />


- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
