### PR TITLE
feat(pick): make key query process respect the 'iminsert' option

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -3682,6 +3682,7 @@ end
 H.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
 
 H.get_lmap = function()
+  if vim.o.keymap == '' then return {} end
   local lmap = {}
   for _, map in ipairs(vim.fn.maplist()) do
     if map.mode == 'l' then lmap[map.lhs] = map.rhs end

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -2200,11 +2200,12 @@ H.picker_advance = function(picker)
   vim.schedule(function() vim.api.nvim_exec_autocmds('User', { pattern = 'MiniPickStart' }) end)
 
   local do_match, is_aborted = false, false
+  local lmap = H.get_lmap()
   for _ = 1, 1000000 do
     if H.cache.is_force_stop_advance then break end
     H.picker_update(picker, do_match)
 
-    local char = H.getcharstr(picker.opts.delay.async)
+    local char = H.getcharstr(picker.opts.delay.async, vim.o.iminsert == 0 and {} or lmap)
     if H.cache.is_force_stop_advance then break end
 
     is_aborted = char == nil

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -2861,7 +2861,7 @@ H.picker_get_current_item = function(picker)
 end
 
 H.picker_get_register_contents = function(picker)
-  local register = H.getcharstr(picker.opts.delay.async)
+  local register = H.getcharstr(picker.opts.delay.async, {})
   -- Mimic some "insert object under cursor" behavior of Command-line mode
   local expand_var = ({ ['\1'] = '<cWORD>', ['\6'] = '<cfile>', ['\23'] = '<cword>' })[register]
   if expand_var then

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -3681,4 +3681,12 @@ end
 -- TODO: Remove after compatibility with Neovim=0.9 is dropped
 H.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
 
+H.get_lmap = function()
+  local lmap = {}
+  for _, map in ipairs(vim.fn.maplist()) do
+    if map.mode == 'l' then lmap[map.lhs] = map.rhs end
+  end
+  return lmap
+end
+
 return MiniPick

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -3586,7 +3586,7 @@ H.redraw = function() vim.cmd('redraw') end
 
 H.redraw_scheduled = vim.schedule_wrap(H.redraw)
 
-H.getcharstr = function(delay_async)
+H.getcharstr = function(delay_async, lmap)
   -- Ensure that redraws still happen
   H.timers.getcharstr:start(0, delay_async, H.redraw_scheduled)
   H.cache.is_in_getcharstr = true
@@ -3599,7 +3599,7 @@ H.getcharstr = function(delay_async)
   if H.pickers.active ~= nil then main_win_id = H.pickers.active.windows.main end
   local is_bad_mouse_click = vim.v.mouse_winid ~= 0 and vim.v.mouse_winid ~= main_win_id
   if not ok or char == '' or char == '\3' or is_bad_mouse_click then return end
-  return char
+  return lmap[char] or char
 end
 
 H.tolower = (function()


### PR DESCRIPTION
The 'getcharstr' returns a character from the input as is, and it is not affected by the 'iminsert' option.

It is possible, however, to construct a lookup table for ':lmap' mappings and apply it to the returned character on the fly.

This successfully emulates the 'iminsert' option in the 'mini.pick' input field.

However, the 'iminsert' toggle has to be defined in 'mini.pick' configuration as a keybinding, as the standard '<C-^>' has no effect by default.

The lookup table is created only once and then cached. In my non-scientific testing, thie feature has no impact on input latency.

The feature has no effect if the 'keymap' option is not set.

I understand that 'iminsert' is a relatively niche feature to cover, and it was never mentioned in issues or discussions. While you can always change the keyboard layout, and achieve the desired effect, it feels unnatural to me. I write quite a lot in the 'iminsert' mode, and find it easier to invoke than the keyboard layout change.

I thought to raise the issue beforehand, but the implementation is quite trivial, so I decided to raise the PR outright.

I intentionally did not update the documentation or anything. If you want to move forward with the feature, I am ready and willing to follow your lead and bring the change up to standard.

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
