### PR TITLE
docs(files): add `config.windows.width_preview`, improve `refresh` help

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -716,8 +716,8 @@ file/directory under cursor. Notes:
 - File preview is highlighted if its size is small enough (less than 1K
   bytes per line or 1M bytes in total).
 
-`windows.width_focus` and `windows.width_nofocus` are number of columns used
-as `width` for focused and non-focused windows respectively.
+`windows.width_focus`, `windows.width_nofocus` and `windows.width_preview`
+are number of columns used as `width` for the corresponding window type.
 
 ------------------------------------------------------------------------------
                                                               *MiniFiles.open()*
@@ -763,7 +763,8 @@ Notes:
   buffers are forced to update.
 
 Parameters ~
-{opts} `(table|nil)` Table of options to update.
+{opts} `(table|nil)` Table of options overriding local options of active
+  explorer session.
 
 ------------------------------------------------------------------------------
                                                        *MiniFiles.synchronize()*
@@ -912,7 +913,7 @@ Parameters ~
 {branch} `(table)` Array of strings representing actually present on disk paths.
   Each consecutive pair should represent direct parent-child paths.
   Should contain at least one directory path.
-  May end with file path (will be previwed).
+  May end with file path (will be previewed).
   Relative paths are resolved using |current-directory|.
 {opts} `(table|nil)` Options. Possible fields:
   - <depth_focus> `(number)` - an index in `branch` for path to focus. Will

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -687,8 +687,8 @@ end
 --- - File preview is highlighted if its size is small enough (less than 1K
 ---   bytes per line or 1M bytes in total).
 ---
---- `windows.width_focus` and `windows.width_nofocus` are number of columns used
---- as `width` for focused and non-focused windows respectively.
+--- `windows.width_focus`, `windows.width_nofocus` and `windows.width_preview`
+--- are number of columns used as `width` for the corresponding window type.
 MiniFiles.config = {
   -- Customization of shown content
   content = {
@@ -831,7 +831,8 @@ end
 --- - If in `opts` at least one of `content` entry is not `nil`, all directory
 ---   buffers are forced to update.
 ---
----@param opts table|nil Table of options to update.
+---@param opts table|nil Table of options overriding local options of active
+---   explorer session.
 MiniFiles.refresh = function(opts)
   local explorer = H.explorer_get()
   if explorer == nil then return end
@@ -1134,7 +1135,7 @@ end
 ---@param branch table Array of strings representing actually present on disk paths.
 ---   Each consecutive pair should represent direct parent-child paths.
 ---   Should contain at least one directory path.
----   May end with file path (will be previwed).
+---   May end with file path (will be previewed).
 ---   Relative paths are resolved using |current-directory|.
 ---@param opts table|nil Options. Possible fields:
 ---   - <depth_focus> `(number)` - an index in `branch` for path to focus. Will


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

In the docs, `windows.width_preview` was missing in the section clarifying config.windows.

In `MiniFiles.refresh`, I changed the description of `opts`.
I also corrected a spelling mistake. 
