### PR TITLE
test(pick): react to Nightly improving `bufdelete` from floating windows

### DIFF
--- a/tests/test_pick.lua
+++ b/tests/test_pick.lua
@@ -2125,10 +2125,9 @@ T['default_choose()']['works for directory path'] = function()
     validate_buf_name(buf_id_init, path)
 
     -- Cleanup
-    child.api.nvim_buf_delete(buf_id_init, { force = true })
-    child.api.nvim_buf_delete(buf_id_cur, { force = true })
-
     child.lua('if _G.MiniFiles ~= nil then _G.MiniFiles.close() end')
+    pcall(child.api.nvim_buf_delete, buf_id_init, { force = true })
+    pcall(child.api.nvim_buf_delete, buf_id_cur, { force = true })
   end
 
   validate(test_dir, test_dir, 'netrw')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [39800](https://github.com/neovim/neovim/pull/39800) in neovim/neovim

I think this is a complicated one...

Somehow, in `tests/test_pick.lua | default_choose() | works for directory path`, with mini.files, the deletion of `buf_id_init` fails: Failed to unload buffer.

I replayed the test steps manually and did not see anything unusual. Deleting the initial buffer when mini.files is open seems to work just fine.


