### PR TITLE
fix(basics): use vim.hl.hl_op() on Neovim>=0.13 instead of on_yank

### DIFF
--- a/doc/mini-basics.txt
+++ b/doc/mini-basics.txt
@@ -335,8 +335,9 @@ Usage example: >lua
 The `config.autocommands.basic` creates some common autocommands:
 
 - Starts insert mode when opening terminal (see |:startinsert| and |TermOpen|).
-- Highlights yanked text for a brief period of time. See |vim.hl.on_yank()|
-  (which is |vim.highlight.on_yank()| on Neovim<0.11) and |TextYankPost|.
+- Highlights yanked text for a brief period of time. See |vim.hl.hl_op()|
+  (which is |vim.hl.on_yank()| on Neovim<0.13 and |vim.highlight.on_yank()|
+  on Neovim<0.11) and |TextYankPost|.
 
 ## autocommands.relnum_in_visual_mode ~
 

--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -314,8 +314,9 @@ end
 --- The `config.autocommands.basic` creates some common autocommands:
 ---
 --- - Starts insert mode when opening terminal (see |:startinsert| and |TermOpen|).
---- - Highlights yanked text for a brief period of time. See |vim.hl.on_yank()|
----   (which is |vim.highlight.on_yank()| on Neovim<0.11) and |TextYankPost|.
+--- - Highlights yanked text for a brief period of time. See |vim.hl.hl_op()|
+---   (which is |vim.hl.on_yank()| on Neovim<0.13 and |vim.highlight.on_yank()|
+---   on Neovim<0.11) and |TextYankPost|.
 ---
 --- ## autocommands.relnum_in_visual_mode ~
 ---
@@ -716,7 +717,8 @@ H.apply_autocommands = function(config)
   end
 
   if config.autocommands.basic then
-    local f = function() vim.hl.on_yank() end
+    local f = function() vim.hl.hl_op() end
+    if vim.fn.has('nvim-0.13') == 0 then f = function() vim.hl.on_yank() end end
     if vim.fn.has('nvim-0.11') == 0 then f = function() vim.highlight.on_yank() end end
     au('TextYankPost', '*', f, 'Highlight yanked text')
 

--- a/tests/test_basics.lua
+++ b/tests/test_basics.lua
@@ -806,9 +806,9 @@ T['Autocommands'] = new_set()
 
 T['Autocommands']['work'] = function()
   child.lua([[
-    local on_yank = function() _G.been_here = true end
     local module = vim.fn.has('nvim-0.11') == 1 and vim.hl or vim.highlight
-    module.on_yank = on_yank
+    local hl_op_name = vim.fn.has('nvim-0.13') == 1 and 'hl_op' or 'on_yank'
+    module[hl_op_name] = function() _G.been_here = true end
   ]])
   load_module()
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- Start using `vim.hl.hl_op()`

- See PR [39777](https://github.com/neovim/neovim/pull/39777) in neovim/neovim
