### PR TITLE
test(keymap): react to Nightly changes regarding autoindent

### DIFF
--- a/tests/test_keymap.lua
+++ b/tests/test_keymap.lua
@@ -1080,6 +1080,7 @@ T['map_multistep()']['built-in steps']['nvimautopairs_cr'] = function()
   eq(get_lines(), { '', '' })
 
   mock_plugin('nvim-autopairs')
+  child.bo.autoindent = false
 
   -- Should respect pairs
   type_keys('()', '<Left>')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [39961](https://github.com/neovim/neovim/pull/39961) in neovim/neovim

I wasn't able to fix this properly. The test now passes because I disabled `autoindent`, allowing the third line to be empty.

I wonder why the `nvim-autopairs` mock is more specific than the other mocks, which mostly add a line to the `_G.log`. Is the comment stating `-- Mock exactly how 'nvim-autopairs' works here` still applicable? Perhaps a simple `_G.log` addition is enough.

The failing test:

```lua
FAIL in tests/test_keymap.lua | map_multistep() | built-in steps | nvimautopairs_cr:
  Failed expectation for equality
  Cause: different values at key 3, left = ")", right = ""
  Left:  { "", "(", ")", "" }
  Right: { "", "(", "", ")" }
  Traceback:
    tests/test_keymap.lua:1088
```

EDIT:
I think [this](https://github.com/neovim/neovim/issues/37780) issue can also be closed...

EDIT2:
It's strange that the third empty line is now subject to truncation. Maybe the vim-patch is not selective enough?
