### PR TITLE
fix(files): remove invalid window from `explorer.windows`

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1544,14 +1544,8 @@ H.explorer_refresh = function(explorer, opts)
     explorer = H.explorer_sync_cursor_and_branch(explorer, depth)
   end
 
-  -- Unregister windows from showed buffers, as they might get outdated
-  for _, win_id in ipairs(explorer.windows) do
-    -- NOTE: window can be invalid if it was showing buffer that was deleted
-    if H.is_valid_win(win_id) then
-      local buf_id = vim.api.nvim_win_get_buf(win_id)
-      H.opened_buffers[buf_id].win_id = nil
-    end
-  end
+  -- Unregister windows from shown buffers, as they might get outdated
+  explorer = H.explorer_unregister_windows(explorer)
 
   -- Compute depth range which is possible to show in current window
   local depth_range = H.compute_visible_depth_range(explorer, explorer.opts)
@@ -1681,6 +1675,20 @@ H.explorer_sync_cursor_and_branch = function(explorer, depth)
   local is_cur_buf = explorer.depth_focus == depth
   if show_preview and is_cur_buf then table.insert(explorer.branch, cursor_path) end
 
+  return explorer
+end
+
+H.explorer_unregister_windows = function(explorer)
+  local valid_windows = {}
+  for i, win_id in ipairs(explorer.windows) do
+    -- NOTE: window can be invalid if it was showing buffer that was deleted
+    if H.is_valid_win(win_id) then
+      local buf_id = vim.api.nvim_win_get_buf(win_id)
+      H.opened_buffers[buf_id].win_id = nil
+      table.insert(valid_windows, win_id)
+    end
+  end
+  explorer.windows = valid_windows
   return explorer
 end
 

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -5733,6 +5733,19 @@ T['Events']['`MiniFilesWindowUpdate` can customize internally set window config 
   expect_screenshot()
 end
 
+T['Events']['MiniFilesWindowUpdate with preview works with `get_explorer_state()` after `undo`'] = function()
+  child.lua('MiniFiles.config.windows.preview = true')
+  child.lua([[
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'MiniFilesWindowUpdate',
+      callback = function() MiniFiles.get_explorer_state() end
+    })
+  ]])
+  open()
+  type_keys('o', '<Esc>', 'u')
+  eq(#get_explorer_state().windows, 2)
+end
+
 T['Events']['`MiniFilesActionCreate` triggers'] = function()
   track_event('MiniFilesActionCreate')
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- When MiniFilesWindowUpdate uses `get_explorer_state()` with enabled preview, an error occurs after the user presses `o`, `<Esc>`, `u`.

The error:

```txt 
Error in User Autocommands for "MiniFilesWindowUpdate":                                                                                                                                      
Lua callback: ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:1105: Invalid window id: 1004                                                                                      
stack traceback:                                                                                                                                                                             
        [C]: in function 'nvim_win_get_buf'                                                                                                                                                  
        ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:1105: in function 'get_explorer_state'                                                                                   
        /home/user/.config/nvim-repro/init.lua:12: in function </home/user/.config/nvim-repro/init.lua:12>                                                                                 
        [C]: in function 'nvim_exec_autocmds'                                                                                                                                                
        ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:3096: in function 'trigger_event'                                                                                        
        ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:1873: in function 'explorer_refresh_depth_window'                                                                        
        ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:1566: in function 'explorer_refresh'                                                                                     
        ...m-repro/site/pack/vnr/start/mini.nvim/lua/mini/files.lua:2147: in function 'fn'                                                                                                   
        [string "vim/_core/editor"]:408: in function <[string "vim/_core/editor"]:407>    
```

Repro:

```lua
require('mini.files').setup({ windows = {  preview = true } })
vim.api.nvim_create_autocmd('User', {
  pattern = 'MiniFilesWindowUpdate',
  callback = function() MiniFiles.get_explorer_state() end,
})
```

1. Open nvim
2. Type `:lua MiniFiles.open()`
3. Type `o` and press `<Esc>`.
4. Type `u`

This happens because the preview buffer is [deleted](https://github.com/nvim-mini/mini.nvim/blob/15abccbe23525ee0502d2efe620c77db00bfb93c/lua/mini/files.lua#L1522). However, `the win_id` is still present in `explorer.windows`.
