### PR TITLE
fix(files): ensure `reveal_cwd` also works when `/` is `cwd`

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1036,7 +1036,7 @@ MiniFiles.reveal_cwd = function()
   local branch, depth_focus = state.branch, state.depth_focus
 
   local cwd = H.fs_full_path(vim.fn.getcwd())
-  local cwd_ancestor_pattern = string.format('^%s/.', vim.pesc(cwd))
+  local cwd_ancestor_pattern = string.format('^%s%s.', vim.pesc(cwd), cwd == '/' and '' or '/')
   while branch[1]:find(cwd_ancestor_pattern) ~= nil do
     table.insert(branch, 1, H.fs_get_parent(branch[1]))
     depth_focus = depth_focus + 1
@@ -3054,7 +3054,7 @@ H.validate_branch = function(x)
   end
   for i = 2, #res do
     local parent, child = res[i - 1], res[i]
-    if (parent .. '/' .. child:match('[^/]+$')) ~= res[i] then
+    if H.fs_child_path(parent, child:match('[^/]+$')) ~= child then
       H.error('`branch` contains not a parent-child pair: ' .. vim.inspect(parent) .. ' and ' .. vim.inspect(child))
     end
   end

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -1861,6 +1861,20 @@ T['reveal_cwd()']['works when root is already cwd'] = function()
   child.expect_screenshot()
 end
 
+T['reveal_cwd()']['works when cwd is `/`'] = function()
+  if not helpers.is_linux() then MiniTest.skip('Test is only for Linux.') end
+
+  child.fn.chdir('/')
+  open('/usr')
+  eq(get_explorer_state().branch, { '/usr' })
+  eq(get_explorer_state().depth_focus, 1)
+
+  reveal_cwd()
+  eq(get_explorer_state().branch, { '/', '/usr' })
+  eq(#get_explorer_state().windows, 2)
+  eq(get_explorer_state().depth_focus, 2)
+end
+
 T['reveal_cwd()']['properly places cursors'] = function()
   child.lua('MiniFiles.config.windows.width_focus = 20')
   local temp_dir =
@@ -2305,6 +2319,14 @@ T['set_branch()']['works with not absolute paths'] = function()
     set_branch({ '..' })
     eq(get_explorer_state().branch, { full_path(test_dir) })
   end
+end
+
+T['set_branch()']['works with `/` and a subdirectory'] = function()
+  if not helpers.is_linux() then MiniTest.skip('Test is only for Linux.') end
+
+  open('/')
+  set_branch({ '/', '/usr' })
+  expect.no_error(reveal_cwd)
 end
 
 T['set_branch()']['sets cursors on child entries'] = function()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Resolve #2443