### PR TITLE
fix(icons): provide a full dummy path as generic filename

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -2160,7 +2160,7 @@ H.get_impl = {
     end
 
     -- Fall back to built-in filetype matching using generic filename
-    local ft = H.filetype_match('aaa.' .. name)
+    local ft = H.filetype_match('/aaa.' .. name)
     if ft ~= nil then return MiniIcons.get('filetype', ft) end
   end,
   file = function(name)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Resolve #2455

When the `cwd` is deleted, `vim.filetype.match` fails when `MiniIcons` queries with filename `aaa.<the_extension>`.

Solution: Add a `/`

@echasnovski, a test is in the making...