### PR TITLE
fix(icons): add guard against a stale `cwd`

### DIFF
--- a/doc/mini-icons.txt
+++ b/doc/mini-icons.txt
@@ -236,7 +236,7 @@ name entry. Example: >lua
       file = { glyph = '󰈤' },
     },
     extension = {
-      -- Override highlight group (not necessary from 'mini.icons')
+      -- Override highlight group (not necessarily from 'mini.icons')
       lua = { hl = 'Special' },
 
       -- Add icons for custom extension. This will also be used in
@@ -267,10 +267,10 @@ output if it is not default). Otherwise extension won't be even considered.
 
 The primary use case for this setting is to ensure that some extensions are
 ignored in order for resolution to reach |vim.filetype.match()| stage. This
-is needed if there is a set up filetype detection for files with recognizable
+is needed if filetype detection has been setup for files with recognizable
 extension and conflicting icons (which you want to use). Note: if problematic
-filetype detection involves only known in advance file names, prefer using
-`config.file` customization.
+filetype detection only involves file names that are known in advance, prefer
+using `config.file` customization.
 
 Example: >lua
 
@@ -283,7 +283,7 @@ Example: >lua
     use_file_extension = function(ext) return ext:sub(-3) ~= 'scm' end
   })
 
-  -- Another common choices for extensions to ignore: "yml", "json", "txt".
+  -- Other common choices for extensions to ignore: "yml", "json", "txt".
 <
 ------------------------------------------------------------------------------
                                                                *MiniIcons.get()*

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -248,7 +248,7 @@ end
 ---       file = { glyph = '󰈤' },
 ---     },
 ---     extension = {
----       -- Override highlight group (not necessary from 'mini.icons')
+---       -- Override highlight group (not necessarily from 'mini.icons')
 ---       lua = { hl = 'Special' },
 ---
 ---       -- Add icons for custom extension. This will also be used in
@@ -279,10 +279,10 @@ end
 ---
 --- The primary use case for this setting is to ensure that some extensions are
 --- ignored in order for resolution to reach |vim.filetype.match()| stage. This
---- is needed if there is a set up filetype detection for files with recognizable
+--- is needed if filetype detection has been setup for files with recognizable
 --- extension and conflicting icons (which you want to use). Note: if problematic
---- filetype detection involves only known in advance file names, prefer using
---- `config.file` customization.
+--- filetype detection only involves file names that are known in advance, prefer
+--- using `config.file` customization.
 ---
 --- Example: >lua
 ---
@@ -295,7 +295,7 @@ end
 ---     use_file_extension = function(ext) return ext:sub(-3) ~= 'scm' end
 ---   })
 ---
----   -- Another common choices for extensions to ignore: "yml", "json", "txt".
+---   -- Other common choices for extensions to ignore: "yml", "json", "txt".
 --- <
 MiniIcons.config = {
   -- Icon style: 'glyph' or 'ascii'

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -2216,7 +2216,14 @@ H.filetype_match = function(filename)
     H.set_buf_name(buf_id, 'filetype-match-scratch')
     H.scratch_buf_id = buf_id
   end
-  return vim.filetype.match({ filename = filename, buf = H.scratch_buf_id })
+  local args = { filename = filename, buf = H.scratch_buf_id }
+  local ok, ft = pcall(vim.filetype.match, args)
+  if ok then return ft end
+
+  -- Force absolute path and retry
+  args.filename = '~/' .. args.filename
+  ok, ft = pcall(vim.filetype.match, args)
+  if ok then return ft end
 end
 
 -- Utilities ------------------------------------------------------------------

--- a/tests/test_icons.lua
+++ b/tests/test_icons.lua
@@ -653,6 +653,22 @@ T['get()']['can be used without `setup()`'] = function()
   eq(child.lua_get('{ require("mini.icons").get("default", "file") }'), { '󰈔', 'MiniIconsGrey', false })
 end
 
+T['get()']['works with deleted cwd'] = function()
+  local temp_dir = 'tests/dir-icons/temp'
+  vim.fn.mkdir(temp_dir, 'p')
+  MiniTest.finally(function() vim.fn.delete(temp_dir, 'rf') end)
+
+  local file_path = child.fn.fnamemodify('tests/dir-icons/file.txt', ':p')
+  child.fn.chdir(temp_dir)
+  vim.fn.delete(temp_dir, 'rf')
+
+  -- Should use `vim.filetype.match` without errors due to missing cwd
+  eq(get('extension', 'xpm'), { '󰍹', 'MiniIconsYellow', false })
+  eq(get('extension', 'unknown'), { '󰈔', 'MiniIconsGrey', true })
+  eq(get('file', 'hello.tcsh'), { '', 'MiniIconsAzure', false })
+  eq(get('file', file_path), { '󰦪', 'MiniIconsYellow', false })
+end
+
 T['get()']['handles deleting all buffers'] = function()
   -- As `vim.filetype.match()` requries a buffer to be more useful, make sure
   -- that there is a persistent helper buffer


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Resolve #2455

Other approaches I considered:

1. Add the pcall to H.filetype_match(). Reasoning: `mini.icons` should never fail...
2. Skip the call with `aaa.<the_extension>`, only test for `~/aaa.<the_extension>`.  Reasoning: `vim.filetype.match` will create an absolute path anyway... 
