### PR TITLE
fix(files): ensure `BufWinEnter` after `:edit <dir>`

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1381,7 +1381,9 @@ H.create_autocommands = function(config)
     vim.cmd('silent! autocmd! FileExplorer *')
     vim.cmd('autocmd VimEnter * ++once silent! autocmd! FileExplorer *')
 
-    au('BufEnter', '*', H.track_dir_edit, 'Track directory edit')
+    -- - Use `nested` to allow other events (`BufWinEnter` for 'mini.clue')
+    local opts = { nested = true, group = gr, callback = H.track_dir_edit, desc = 'Track directory edit' }
+    vim.api.nvim_create_autocmd('BufEnter', opts)
   end
 
   au('VimResized', '*', MiniFiles.refresh, 'Refresh on resize')

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -6324,6 +6324,13 @@ T['Default explorer']['works in `:tabfind .`'] = function()
 end
 
 T['Default explorer']['handles close without opening file'] = function()
+  child.lua([[
+    _G.log = {}
+    vim.api.nvim_create_autocmd('BufWinEnter', {
+      callback = function(data) table.insert(_G.log, data.buf) end,
+    })
+  ]])
+
   local validate = function()
     local buf_name = child.api.nvim_buf_get_name(0)
     child.cmd('edit ' .. test_dir_path)
@@ -6334,8 +6341,12 @@ T['Default explorer']['handles close without opening file'] = function()
     eq(#child.api.nvim_list_bufs(), 1)
   end
 
-  -- Should hide "directory buffer" if there is no alternative buffer
+  -- Should delete "directory buffer" if there is no alternative buffer
   validate()
+  -- Expect `BufWinEnter` on the buffer replacing "directory buffer"
+  -- This is needed for 'mini.clue' to attach
+  eq(#child.lua_get('_G.log'), 3)
+  eq(child.lua_get('_G.log')[3], child.api.nvim_get_current_buf())
 
   -- Should smartly (preserving layout) delete "directory buffer"
   local win_id_other = child.api.nvim_get_current_win()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- By default, 'mini.files' replaces 'netrw'. When a directory is opened with `:edit <dir>`, and the explorer is closed without opening a file, 'mini.files' shows the alternate buffer if present. If there is no alternate buffer, a new buffer is created. Event `BufWinEnter` needs to fire in order for `mini.clue` to attach.

Resolve #2466

