### PR TITLE
fix(clue): react to Nightly changes to `keytrans()`

### DIFF
--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1992,7 +1992,7 @@ end
 
 H.keytrans = function(x)
   local res = vim.fn.keytrans(x):gsub('<NL>', '<C-J>'):gsub('<S%-NL>', '<C-S-J>'):gsub('<M%-NL>', '<C-M-J>')
-  return (res:gsub('<lt>', '<'))
+  return (res:gsub('<lt>', '<'):gsub('<Bar>', '|'):gsub('<Bslash>', [[\]]))
 end
 
 H.get_forced_submode = function()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- `keytrans()` now also replaces '|' and '\\'
- See PR [40345](https://github.com/neovim/neovim/pull/40345) in neovim/neovim
