### PR TITLE
fix(files): avoid closing directory buffer when #windows decreases

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -922,11 +922,6 @@ MiniFiles.close = function()
   -- Trigger appropriate event
   H.trigger_event('MiniFilesExplorerClose')
 
-  -- Focus on target window
-  explorer = H.explorer_ensure_target_window(explorer)
-  -- - Use `pcall()` because window might still be invalid
-  pcall(vim.api.nvim_set_current_win, explorer.target_window)
-
   -- Update currently shown cursors
   explorer = H.explorer_update_cursors(explorer)
 
@@ -950,6 +945,11 @@ MiniFiles.close = function()
   -- Update histories and unmark as opened
   H.explorer_path_history[explorer.anchor] = explorer
   H.opened_explorers[explorer.tabpage_id] = nil
+
+  -- Focus on target window
+  explorer = H.explorer_ensure_target_window(explorer)
+  -- - Use `pcall()` because window might still be invalid
+  pcall(vim.api.nvim_set_current_win, explorer.target_window)
 
   -- Return `true` indicating success in closing
   return true
@@ -1427,6 +1427,9 @@ H.track_dir_edit = function(data)
   if vim.api.nvim_get_current_buf() ~= data.buf then return end
 
   if vim.b.minifiles_processed_dir then
+    -- Only delete directory buffer explicitly when explorer is closed
+    if H.explorer_get() ~= nil then return end
+
     -- Smartly delete directory buffer if already visited
     local alt_buf = vim.fn.bufnr('#')
     -- - Setting alternative buffer is enough for the "directory buffer" to be

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -6369,6 +6369,32 @@ T['Default explorer']['handles forcing other window as current'] = function()
   if child.fn.has('nvim-0.10') == 1 then eq(child.api.nvim_get_current_win(), init_win_id) end
 end
 
+T['Default explorer']['keeps directory buffer open when number of windows decreases'] = function()
+  local validate = function(fn_str)
+    child.cmd('edit ' .. make_test_path('nested'))
+
+    local buffers = child.api.nvim_list_bufs()
+    local dir_buffer_id = buffers[1]
+    eq(child.fn.isdirectory(child.api.nvim_buf_get_name(dir_buffer_id)), 1)
+
+    go_in()
+    go_in()
+    child.lua(fn_str)
+
+    -- Assert directory buffer still present
+    eq(child.api.nvim_buf_is_valid(dir_buffer_id), true)
+    -- Assert directory buffer deleted
+    close()
+    eq(child.api.nvim_buf_is_valid(dir_buffer_id), false)
+  end
+  -- Ensure enough space for 3 windows
+  child.set_size(5, 90)
+  -- Shrink number of windows using refresh
+  validate('MiniFiles.refresh({ windows = { max_number = 1 } })')
+  -- Shrink number of windows using trim_left
+  validate('MiniFiles.trim_left()')
+end
+
 T['Internal helpers'] = new_set()
 
 T['Internal helpers']['path normalization works'] = function()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)


https://github.com/user-attachments/assets/ade11fd4-8e7e-427a-a1e4-351f0a39b34d

Whilst working on [this](https://github.com/nvim-mini/mini.nvim/discussions/2448#discussioncomment-17362786) discussion, I saw inconsistencies with regard to the closing of the underlying directory buffer.

When decreasing the number of windows, there are circumstances where the directory buffer is closed. 

```lua

-- Only added for visual feedback:
require('mini.tabline').setup()
require('mini.statusline').setup()

require('mini.files').setup()

```

It happens when 2 or more windows are closed.

Scenario:

- Open nvim
- Type `:edit .`
- Type `ll`
- Notice that the directory buffer is still open
- Type `<`
- Notice that the directory buffer is closed

The video demonstrates "depth_focus = 3", using both `MiniFiles.refresh()` and `MiniFiles.trim_left()`. The second part shows the same scenario with the solution applied.

In the source code, there are two locations where the behavior is triggered:
- [ refresh, explorer normalize](https://github.com/nvim-mini/mini.nvim/blob/c594be5b095204e99473825ec2dee872e7409a4d/lua/mini/files.lua#L1645)
- [ refresh, after the loop](https://github.com/nvim-mini/mini.nvim/blob/c594be5b095204e99473825ec2dee872e7409a4d/lua/mini/files.lua#L1574)

Unfortunately, I don't understand why [BufEnter](https://github.com/nvim-mini/mini.nvim/blob/c594be5b095204e99473825ec2dee872e7409a4d/lua/mini/files.lua#L1425) is triggered prematurely on the directory buffer. I assume it has to do with alternate files.

I fixed it by ensuring that in `BufEnter` the directory buffer is only explicitly closed if the explorer is closed.

