### PR TITLE
test(ALL): react to Nightly adding filetype `directory`

### DIFF
--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -6285,7 +6285,9 @@ end
 T['Default explorer']['respects `options.use_as_default_explorer`'] = function()
   vim.loop.os_setenv('USE_AS_DEFAULT_EXPLORER', 'false')
   child.restart({ '-u', make_test_path('init-default-explorer.lua'), '--', test_dir_path })
-  eq(child.bo.filetype, 'netrw')
+
+  local directory_filetype = child.fn.has('nvim-0.13') == 0 and 'netrw' or 'directory'
+  eq(child.bo.filetype, directory_filetype)
 end
 
 T['Default explorer']['works in `:edit .`'] = function()

--- a/tests/test_pick.lua
+++ b/tests/test_pick.lua
@@ -2257,8 +2257,9 @@ T['default_choose()']['works for directory path'] = function()
     pcall(child.api.nvim_buf_delete, buf_id_cur, { force = true })
   end
 
-  validate(test_dir, test_dir, 'netrw')
-  validate({ text = test_dir, path = test_dir }, test_dir, 'netrw')
+  local directory_filetype = child.fn.has('nvim-0.13') == 0 and 'netrw' or 'directory'
+  validate(test_dir, test_dir, directory_filetype)
+  validate({ text = test_dir, path = test_dir }, test_dir, directory_filetype)
 
   -- Should work with 'mini.files' as default explorer
   child.lua('require("mini.files").setup()')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [39723](https://github.com/neovim/neovim/pull/39723) in neovim/neovim

There are still 2 tests failing(`mini.clue` and `mini.jump2d`) because of PR 40325 - `cmdwin normal buf + win`

