### PR TITLE
fix(jump2d): ensure that `CR` works in the new cmdwin on Nightly

### DIFF
--- a/lua/mini/jump2d.lua
+++ b/lua/mini/jump2d.lua
@@ -790,7 +790,11 @@ H.create_autocommands = function(config)
 
   -- Corrections for default `<CR>` mapping to not interfere with popular usages
   if config.mappings.start_jumping == '<CR>' then
-    local revert_cr = function() vim.keymap.set('n', '<CR>', '<CR>', { buffer = true }) end
+    local revert_cr = function()
+      -- Don't revert when there is an existing buffer local mapping
+      if vim.fn.maparg('<CR>', 'n', false, true).buffer == 1 then return end
+      vim.keymap.set('n', '<CR>', '<CR>', { buffer = true })
+    end
     au('FileType', 'qf', revert_cr, 'Revert <CR>')
     au('CmdwinEnter', '*', revert_cr, 'Revert <CR>')
   end

--- a/tests/test_jump2d.lua
+++ b/tests/test_jump2d.lua
@@ -206,6 +206,12 @@ T['setup()']['resets <CR> mapping in quickfix window'] = function()
   child.cmd([[cexpr ['Hello', 'Quickfix'] | copen]])
   -- Should create not remappable buffer-local mapping
   expect.match(child.cmd_capture('nmap <CR>'), '%*@<CR>')
+
+  child.cmd('au FileType qf nnoremap <buffer> <CR> <Cmd><CR>')
+  reload_module()
+  child.cmd([[cexpr ['Hello', 'Quickfix'] | copen]])
+  -- Should not create buffer-local mapping if its already present
+  expect.no_match(child.cmd_capture('nmap <CR>'), '%*@<CR>')
 end
 
 T['setup()']['resets <CR> mapping in command-line window'] = function()
@@ -214,7 +220,15 @@ T['setup()']['resets <CR> mapping in command-line window'] = function()
   type_keys('q:')
   set_cursor(1, 0)
   type_keys('<CR>')
+  -- Should create not remappable buffer-local mapping if needed
   eq(child.get_lines(), { 'Hello', '' })
+
+  child.cmd('au CmdwinEnter * nnoremap <buffer> <CR> <Cmd><CR>')
+  type_keys('q:')
+  set_cursor(1, 0)
+  type_keys('<CR>')
+  -- Should not create buffer-local mapping if its already present
+  eq(child.get_lines(), { [[call append(0, 'Hello')]], '' })
 end
 
 T['start()'] = new_set({


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [40325](https://github.com/neovim/neovim/pull/40325) in neovim/neovim
