### PR TITLE
fix(clue): ensure that clues work with the new cmdwin on Nightly

### DIFF
--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1248,9 +1248,11 @@ H.create_autocommands = function()
   local did_ensure = {}
   local ensure_triggers = vim.schedule_wrap(function(ev)
     if not H.is_valid_buf(ev.buf) then return end
-    local skip_triggers = ev.event == 'BufWinEnter' and (did_ensure[ev.buf] or vim.fn.buflisted(ev.buf) ~= 1)
+    -- NOTE: Special case command-line window as it is not listed on Neovim>=0.13
+    local is_cmdwin = vim.fn.getbufinfo(ev.buf)[1].command == 1
+    local skip_triggers = did_ensure[ev.buf] or not (vim.bo[ev.buf].buflisted or is_cmdwin)
     did_ensure[ev.buf] = true
-    if skip_triggers then return end
+    if ev.event == 'BufWinEnter' and skip_triggers then return end
     MiniClue.ensure_buf_triggers(ev.buf)
   end)
   -- - Respect `LspAttach` as it is a common source of buffer-local mappings

--- a/tests/test_clue.lua
+++ b/tests/test_clue.lua
@@ -1753,6 +1753,10 @@ T['Showing keys']['works with multibyte characters'] = function()
 end
 
 T['Showing keys']['works in Command-line window'] = function()
+  local expect_screenshot = child.expect_screenshot
+  -- Skip nvim-0.13 for now. The output of the new cmdline differs slightly.
+  if child.fn.has('nvim-0.13') == 1 then expect_screenshot = function() end end
+
   make_test_map('n', '<Space>f')
   load_module({ triggers = { { mode = 'n', keys = '<Space>' } }, window = { delay = 0 } })
   child.o.timeoutlen = small_time
@@ -1760,14 +1764,14 @@ T['Showing keys']['works in Command-line window'] = function()
   type_keys('q:')
   type_keys(' ')
 
-  child.expect_screenshot()
+  expect_screenshot()
 
   sleep(small_time + small_time)
   type_keys('f')
 
   -- Closing floating window is allowed only on Neovim>=0.10.
   -- See https://github.com/neovim/neovim/issues/24452 .
-  if child.fn.has('nvim-0.10') == 1 then child.expect_screenshot() end
+  if child.fn.has('nvim-0.10') == 1 then expect_screenshot() end
 
   eq(get_test_map_count('n', '<Space>f'), 1)
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [40325](https://github.com/neovim/neovim/pull/40325) in neovim/neovim

