### PR TITLE
fix(splitjoin): handle empty positions in split

### DIFF
--- a/lua/mini/splitjoin.lua
+++ b/lua/mini/splitjoin.lua
@@ -346,6 +346,8 @@ MiniSplitjoin.split = function(opts)
     positions = hook(positions)
   end
 
+  if #positions == 0 then return nil end
+
   -- Split at positions
   local split_positions = MiniSplitjoin.split_at(positions)
 


### PR DESCRIPTION
why is this a problem? well, i took your advice from #2470 to heart and
implemented the fennel logic entirely with hooks. but one minor hiccup
was revealed when i tried to do this:

```lua
-- brackets stay close to the first and last elements
local function lisp_split(positions)
        if #positions < 2 then
                return positions
        end

        -- here specifically, i am NOT splitting if a
        -- list only has 1 index or 1 key-value pair
        local res = {}
        for i = 2, #positions - 1 do
                res[i - 1] = positions[i]
        end

        return res
end
```

where on line 354 it would attempt to index local 'last' (a nil value).
i thought it'd be ugly if i allowed splits here and the rest is history.
i figure that this patch is simple enough that it won't trouble you this
time. keep up the good work! i love your plugins
