### PR TITLE
fix(files): stop `nvim.dir` from showing if `files` is default explorer

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1376,11 +1376,7 @@ H.create_autocommands = function(config)
   end
 
   if config.options.use_as_default_explorer then
-    -- Stop 'netrw' from showing. Needs `VimEnter` event autocommand if
-    -- this is called prior 'netrw' is set up
-    vim.cmd('silent! autocmd! FileExplorer *')
-    vim.cmd('autocmd VimEnter * ++once silent! autocmd! FileExplorer *')
-
+    H.prevent_builtin_explorer()
     -- - Use `nested` to allow other events (`BufWinEnter` for 'mini.clue')
     local opts = { nested = true, group = gr, callback = H.track_dir_edit, desc = 'Track directory edit' }
     vim.api.nvim_create_autocmd('BufEnter', opts)
@@ -1388,6 +1384,18 @@ H.create_autocommands = function(config)
 
   au('VimResized', '*', MiniFiles.refresh, 'Refresh on resize')
   au('ColorScheme', '*', H.create_default_hl, 'Ensure colors')
+end
+
+H.prevent_builtin_explorer = function()
+  -- Stop 'netrw' from showing. Needs `VimEnter` event autocommand if
+  -- this is called prior 'netrw' is set up
+  vim.cmd('silent! autocmd! FileExplorer *')
+  vim.cmd('autocmd VimEnter * ++once silent! autocmd! FileExplorer *')
+  if vim.fn.has('nvim-0.13') == 0 then return end
+
+  -- Stop nvim.dir from showing.
+  vim.cmd('silent! autocmd! nvim.dir *')
+  vim.cmd('autocmd VimEnter * ++once silent! autocmd! nvim.dir *')
 end
 
 --stylua: ignore


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [40507](https://github.com/neovim/neovim/pull/40507) in neovim/neovim

Tests that failed:
- `Default explorer | works on startup:`
- `Default explorer | works in `:edit .`
- `Default explorer | works in `:tabfind .`
- `Default explorer | handles close without opening file`

Surprisingly, test `Default explorer works in :vsplit` did not fail. ~Probably~ because of the `vsplit`...) 


Before the fix, `vim.fn.getbufinfo(1)`:
```txt
    ...
    variables = {                                                                                                                                                                            
      changedtick = 4,                                                                                                                                                                       
      current_syntax = "directory",                                                                                                                                                          
      minifiles_processed_dir = true,                                                                                                                                                        
      nvim_dir = "/home/user/.config/repro"                                                                                                                                                 
    }, 
    ...       
```

After:
```txt
    ...
    variables = {                                                                                                                                                                            
      changedtick = 3,                                                                                                                                                                       
      minifiles_processed_dir = true                                                                                                                                                         
    }, 
    ... 
```
 
