### PR TITLE
fix(git): respect variable prefix indent when completing options

### DIFF
--- a/lua/mini/git.lua
+++ b/lua/mini/git.lua
@@ -965,15 +965,17 @@ H.command_complete_option = function(command)
   -- Options are assumed to be listed inside "OPTIONS" or "XXX OPTIONS" (like
   -- "MODE OPTIONS" of `git rebase`) section on dedicated lines. Whether a line
   -- contains only options is determined heuristically: it is assumed to start
-  -- exactly with "       -" indicating proper indent for subsection start.
+  -- with spaces ending with '-', indicating proper indent for subsection start.
+  -- The amount of spaces can differ per system.
   -- Known not parsable options:
   -- - `git reset <mode>` (--soft, --hard, etc.): not listed in "OPTIONS".
   -- - All -<number> options, as they are not really completable.
-  local is_in_options_section = false
+  local is_in_options_section, prefix = false, nil
   for _, l in ipairs(lines) do
     if is_in_options_section and l:find('^%u[%u ]+$') ~= nil then is_in_options_section = false end
     if not is_in_options_section and l:find('^%u?[%u ]*OPTIONS$') ~= nil then is_in_options_section = true end
-    if is_in_options_section and l:find('^       %-') ~= nil then H.parse_options(candidates_map, l) end
+    if is_in_options_section and prefix == nil then prefix = l:match('^ +%-') end
+    if is_in_options_section and prefix ~= nil and vim.startswith(l, prefix) then H.parse_options(candidates_map, l) end
   end
 
   -- Finalize candidates. Should not contain "almost duplicates".


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Git option completion fails when options are not indented by 7 spaces. Unfortunately, it seems that the number of spaces used varies per system.

This PR creates the regular expression dynamically, parsing the nr of spaces of the first valid option. That should be the first line after 'OPTIONS' starting with at least one space ending in '-'