### PR TITLE
test(pick): adjust `validate_buf_name()` after Nightly changes

### DIFF
--- a/tests/test_pick.lua
+++ b/tests/test_pick.lua
@@ -70,6 +70,11 @@ local validate_buf_name = function(buf_id, ref_name)
   local name = child.api.nvim_buf_get_name(buf_id):gsub('\\', '/')
   ref_name = ref_name ~= '' and full_path(ref_name) or ''
   ref_name = ref_name:gsub('\\', '/'):gsub('[\\/]+$', '')
+
+  if child.fn.has('nvim-0.13') == 1 then
+    local ft = child.api.nvim_get_option_value('filetype', { buf = buf_id })
+    ref_name = ref_name .. (ft == 'directory' and '/' or '')
+  end
   eq(name, ref_name)
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- On Nightly, the name of a directory buffer always ends with '/'.
- See PR [40552](https://github.com/neovim/neovim/pull/40552) in neovim/neovim.
