### PR TITLE
fix(files): ensure that file-preview includes the first column

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2577,9 +2577,13 @@ H.window_set_view = function(win_id, view)
   buf_data.win_id = win_id
 
   -- Set cursor (if defined), visible only in directories
-  pcall(H.window_set_cursor, win_id, view.cursor)
+  local ok_cursor = pcall(vim.api.nvim_win_set_cursor, win_id, view.cursor)
+  -- - Tweak cursor here, before `CursorMoved`, event to reduce flicker
+  local is_dir = H.fs_get_type(buf_data.path) == 'directory'
+  if ok_cursor and is_dir then pcall(H.window_tweak_cursor, win_id, buf_id) end
+
   -- NOTE: set 'cursorline[opt]' here because changing buffer might remove it
-  vim.wo[win_id].cursorline = H.fs_get_type(buf_data.path) == 'directory'
+  vim.wo[win_id].cursorline = is_dir
   local culopt = vim.wo[win_id].cursorlineopt
   if culopt:find('line') == nil then vim.wo[win_id].cursorlineopt = culopt .. ',line' end
 
@@ -2589,15 +2593,6 @@ H.window_set_view = function(win_id, view)
 
   -- Update border highlight based on buffer status
   H.window_update_border_hl(win_id)
-end
-
-H.window_set_cursor = function(win_id, cursor)
-  if type(cursor) ~= 'table' then return end
-
-  vim.api.nvim_win_set_cursor(win_id, cursor)
-
-  -- Tweak cursor here and don't rely on `CursorMoved` event to reduce flicker
-  H.window_tweak_cursor(win_id, vim.api.nvim_win_get_buf(win_id))
 end
 
 H.window_tweak_cursor = function(win_id, buf_id)

--- a/tests/dir-files/real/b.txt
+++ b/tests/dir-files/real/b.txt
@@ -1,4 +1,4 @@
-Line 1
+// Preview of a file should include the first column, even when the first line is long and has 3 slashes/
 Line 2
 Line 3
 Line 4

--- a/tests/screenshots/tests-test_files.lua---Preview---works-for-files-002
+++ b/tests/screenshots/tests-test_files.lua---Preview---works-for-files-002
@@ -1,6 +1,6 @@
 --|---------|---------|---------|---------|---------|---------|---------|---------|
 01|┌OOT/tests/dir-files/real ┐┌ b.txt ──────────────────┐                          
-02|│ a.lua                  ││Line 1                   │                          
+02|│ a.lua                  ││// Preview of a file shou│                          
 03|│ b.txt                  ││Line 2                   │                          
 04|│ c.gif                  ││Line 3                   │                          
 05|│ LICENSE                ││Line 4                   │                          


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Resolve #2514


Test `Preview works for files` has been modified to also include the case where the preview did not start from zero cursor position. As a consequence, I had to regenerate some screenshots in test cases also using the `real_path` directory.
