### PR TITLE
test(completion): react to Nightly changing highlight without `hl_eol`

### DIFF
--- a/tests/test_completion.lua
+++ b/tests/test_completion.lua
@@ -2559,7 +2559,7 @@ T['Snippets']['show full snippet text as info'] = function()
   -- Should show full snippet text as info
   type_keys('i', 'M', '<C-Space>', '<C-n>')
   sleep(default_info_delay + small_time)
-  child.expect_screenshot()
+  child.expect_screenshot({ ignore_attr = true })
 
   type_keys('<C-e>', '<Esc>')
   set_lines({ '' })


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [41160](https://github.com/neovim/neovim/pull/41160) in neovim/neovim
