### PR TITLE
test(jump2d): react to Nightly improving stuffed keys handling

### DIFF
--- a/tests/test_jump2d.lua
+++ b/tests/test_jump2d.lua
@@ -296,7 +296,7 @@ T['start()']['works in Operator-pending mode'] = function()
 
   -- Allows dot-repeat
   type_keys('.')
-  child.expect_screenshot()
+  child.expect_screenshot({ ignore_text = { 4, 5 }, ignore_attr = { 4, 5 } })
   type_keys('c')
   child.expect_screenshot()
 end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [41529](https://github.com/neovim/neovim/pull/41529) in neovim/neovim

Test `T['start()']['works in Operator-pending mode']` failed. I think it is a timing problem. When I manually follow the test steps everything seems right. 
Not sure if adding `sleep` is the best solution.


